### PR TITLE
Make nweights consistent across classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This library provides no training algorithm. You can easily set up a neuroevolut
 ## Usage
 
 ```python
-from tinynet import RNN1L
+from tinynet import RNN
 import numpy as np
 net_struct = [3, 5, 2]
 net = RNN(net_struct) # try also FFNN

--- a/tinynet/rnn1l.py
+++ b/tinynet/rnn1l.py
@@ -52,6 +52,7 @@ class RNN1L:
     def get_act(self):
         return self.state[self.act_idxs]
 
+    @property
     def nweights(self):
         return self.weights_matrix.size
 


### PR DESCRIPTION
Make nweights a @property in RNN1L, in order to call it with 'net.nweights' as in FFNN and RNN (instead of 'net.nweights()')

Minor fix in README (import class used)